### PR TITLE
OpenGraph 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
-## OpenGraph 0.1.1
+## OpenGraph 0.1.2
 
-* `Get-OpenGraph` now supports unclosed `<meta>` tags (#23)
 * `Test-OpenGraph` and `Test-OGP` are aliases of `Get-OpenGraph` (#22).
   * Additionally, `Get-OpenGraph` now outputs `$false` when no OpenGraph tags are found.
 * `Get-OpenGraph` now accepts any pipeline input and number of arguments (#21)
 * `Get-OpenGraph` correctly outputs cached results (#20)
+* `Get-OpenGraph` internally encapsulates each scenario into a filter (#25)
+
+---
+
+## OpenGraph 0.1.1
+
+* Simplified Module Scaffolding (#14)
+* Supporting open or closed tags (#15)
+* Get-OpenGraph -Html supports direct content (#16)
+* Get-OpenGraph -Url is now positional and pipeable (#17)
+* Improving README (#18)
 
 ---
 

--- a/Commands/Get-OpenGraph.ps1
+++ b/Commands/Get-OpenGraph.ps1
@@ -14,10 +14,7 @@ function Get-OpenGraph
     .EXAMPLE        
         Get-OpenGraph -Url https://abc.com/
     .EXAMPLE        
-        'https://cnn.com/',
-            'https://msnbc.com/',
-                'https://fox.com/' |
-                    Get-OpenGraph
+        'https://thebulwark.com/' | Get-OpenGraph
     .EXAMPLE
         OpenGraph https://posh.pckt.blog/static-sites-are-simple-6u51kgj        
     #>
@@ -64,18 +61,52 @@ function Get-OpenGraph
         if (-not $script:OpenGraphCache) {
             $script:OpenGraphCache = [Ordered]@{}
         }
+
+        filter OpenGraphFromData {
+            $data = $_ -as [Collections.IDictionary]
+            $openGraphMetadata = [Ordered]@{PSTypeName='OpenGraph'}
+            foreach ($key in $Data.Keys) {
+                $openGraphMetadata[$key] = $Data[$key]
+            }
+            [PSCustomObject]$openGraphMetadata
+        }
+
+        filter OpenGraphFromUrl {
+            $url = $_ -as [uri]            
+            if ($script:OpenGraphCache[$url] -and -not $Force) {                
+                return $script:OpenGraphCache[$url]
+            }
+
+            $script:OpenGraphCache[$url] = Invoke-RestMethod -Uri $Url | 
+                OpenGraphFromHtml
+            $script:OpenGraphCache[$url]
+        }
+
+        filter OpenGraphFromHtml {
+            $text = "$_"
+            $openGraphMetadata = [Ordered]@{PSTypeName='OpenGraph'}
+            foreach ($match in $metaRegex.Matches($text)) {
+                $matchXml = (
+                    # close unclosed `<meta>` tags.
+                    "$match" -replace '/?>$','/>'
+                ) -as [xml]
+
+                if ($matchXml.meta.property -and $matchXml.meta.content) {
+                    $openGraphMetadata[$matchXml.meta.property] = $matchXml.meta.content
+                }
+            }
+            [PSCustomObject]$openGraphMetadata
+        }
     }
 
     process {
         # Turn any of our strongly bound parameters into arguments
-        if ($Url) {
-            $argumentList = @($argumentList) + $url
-        }
-
+        if ($Url) {$Url | OpenGraphFromUrl }
         # If any data was provided
-        if ($Data) {
-            $argumentList = @($argumentList) + $Data
-        }
+        if ($Data) {$Data | OpenGraphFromData }
+
+        if ($html) { $Html | OpenGraphFromHtml }
+        
         if ($InputObject) {
             $ArgumentList = @($ArgumentList) + $InputObject
         }
@@ -83,59 +114,40 @@ function Get-OpenGraph
         :nextArgument foreach ($argument in $argumentList) {
             # Declare an empty object to hold the Open Graph metadata            
             if (-not $argument) { continue }
-            $openGraphMetadata = [Ordered]@{PSTypeName='OpenGraph'}
-            $url, $data = $null, $null
+            $openGraphMetadata = [Ordered]@{PSTypeName='OpenGraph'}            
             
-            if ($argument -as [uri]) {
-                $url = $argument -as [uri]
+            $openGraphMetadata = if ($argument -as [uri] -and 
+                $argument -match '^https?://'
+            ) {
+                $argument -as [uri] | OpenGraphFromUrl
             } elseif ($argument -is [Collections.IDictionary]) {
-                $data = $argument
-            } else {
-                Write-Warning "Only [uri] and [Collections.IDictionary] supported: $argument"
+                $argument | OpenGraphFromData
+            } 
+            elseif ($argument -is [string] -and 
+                $argument -match '\<meta') {
+                $argument | OpenGraphFromHtml
+            }
+            else {
+                Write-Warning (
+                    @(
+                        "Unsupported argument:"
+                        "[uri],[Collections.IDictionary], and [string]s matching <meta> are supported: $argument"
+                    ) -join [Environment]::NewLine
+                )
                 continue nextArgument
             }
-
-            if ($Url) {
-                if ($script:OpenGraphCache[$url] -and -not $Force) {
-                    foreach ($key in $script:OpenGraphCache[$url].Keys) {
-                        $openGraphMetadata[$key] =
-                            $script:OpenGraphCache[$url][$key]
-                    }
-                    ([PSCustomObject]$script:OpenGraphCache[$url])
-                    continue nextArgument
-                }
-
-                $restResponse = Invoke-RestMethod -Uri $Url
-                
-                foreach ($match in $metaRegex.Matches("$restResponse")) {
-                    $matchXml = (
-                        # close unclosed `<meta>` tags.
-                        "$match" -replace '/?>$','/>'
-                    ) -as [xml]
-
-                    if ($matchXml.meta.property -and $matchXml.meta.content) {
-                        $openGraphMetadata[$matchXml.meta.property] = $matchXml.meta.content
-                    }
-                }
-
-                $script:OpenGraphCache[$url] = $openGraphMetadata
-            }
-
-            if ($Data) {
-                foreach ($key in $Data.Keys) {
-                    $openGraphMetadata[$key] = $Data[$key]
-                }
-            }
-            
+                    
             # If there was no metadata
-            if (-not $openGraphMetadata.Count) {
+            if (@($openGraphMetadata.psobject.properties).Count -le 1) {
                 # output false (so `Test-` verb scenarios are met)
                 $false
                 # and continue to the next argument.
                 continue nextArgument
             }
 
-            [PSCustomObject]$openGraphMetadata
+            $openGraphMetadata
         }
+
+        $ArgumentList = @()
     }
 }

--- a/OpenGraph.psd1
+++ b/OpenGraph.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'OpenGraph.psm1'
-    ModuleVersion = '0.1.1'
+    ModuleVersion = '0.1.2'
     GUID = 'be4e4070-1ea6-4a2e-8b6a-c6b7755e5ace'
     Author = 'James Brundage'
     CompanyName = 'Start-Automating'
@@ -15,13 +15,13 @@
             ProjectURI = 'https://github.com/PoshWeb/OpenGraph'
             LicenseURI = 'https://github.com/PoshWeb/OpenGraph/blob/main/LICENSE'
             ReleaseNotes = @'
-## OpenGraph 0.1.1
+## OpenGraph 0.1.2
 
-* `Get-OpenGraph` now supports unclosed `<meta>` tags (#23)
 * `Test-OpenGraph` and `Test-OGP` are aliases of `Get-OpenGraph` (#22).
   * Additionally, `Get-OpenGraph` now outputs `$false` when no OpenGraph tags are found.
 * `Get-OpenGraph` now accepts any pipeline input and number of arguments (#21)
 * `Get-OpenGraph` correctly outputs cached results (#20)
+* `Get-OpenGraph` internally encapsulates each scenario into a filter (#25)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Import-Module OpenGraph -PassThru
 You can also clone the repo and import the module locally:
 
 ~~~PowerShell
-git clone https://github.com/PowerShellWeb/OpenGraph
+git clone https://github.com/PoshWeb/OpenGraph
 cd ./OpenGraph
 Import-Module ./ -PassThru
 ~~~
@@ -42,6 +42,7 @@ This function retrieves the Open Graph metadata from a given URL and returns it 
 |-|-|-|
 |ArgumentList|PSObject[]|A list of any arguments. <br/>This allows the command to take natural input.|
 |Url|String|The URL that may contain Open Graph metadata|
+|Html|String|Any HTML that may contain open graph metadata.|
 |Data|IDictionary|A dictionary of additional Open Graph metadata to include in the result|
 |Force|SwitchParameter|If set, forces the function to retrieve the Open Graph metadata even if it is already cached.|
 |InputObject|PSObject[]|Any number of input objects|
@@ -53,14 +54,11 @@ Get-OpenGraph -Url https://abc.com/
 ~~~
 ###### Example 2
 ~~~PowerShell
-'https://cnn.com/',
-    'https://msnbc.com/',
-        'https://fox.com/' |
-            Get-OpenGraph
+'https://thebulwark.com/' | Get-OpenGraph
 ~~~
 ###### Example 3
 ~~~PowerShell
-
+OpenGraph https://posh.pckt.blog/static-sites-are-simple-6u51kgj
 ~~~
 ## Types
 ### OpenGraph
@@ -71,4 +69,4 @@ Get-OpenGraph -Url https://abc.com/
 |[get_HTML](Types/OpenGraph/get_HTML.ps1)|ScriptProperty|
 > (c) 2025-2026 Start-Automating
 
-> [LICENSE](https://github.com/PowerShellWeb/OpenGraph/blob/main/LICENSE)
+> [LICENSE](https://github.com/PoshWeb/OpenGraph/blob/main/LICENSE)


### PR DESCRIPTION
## OpenGraph 0.1.2

* `Test-OpenGraph` and `Test-OGP` are aliases of `Get-OpenGraph` (#22).
  * Additionally, `Get-OpenGraph` now outputs `$false` when no OpenGraph tags are found.
* `Get-OpenGraph` now accepts any pipeline input and number of arguments (#21)
* `Get-OpenGraph` correctly outputs cached results (#20)
* `Get-OpenGraph` internally encapsulates each scenario into a filter (#25)

---